### PR TITLE
Fix markdown rendering

### DIFF
--- a/src/mdviewer/app.py
+++ b/src/mdviewer/app.py
@@ -15,7 +15,21 @@ app = Flask(
     template_folder=os.path.join(BASE_DIR, "templates"),
     static_folder=os.path.join(BASE_DIR, "static"),
 )
-md = MarkdownIt()
+
+# Use GitHub-style Markdown rendering
+md = (
+    MarkdownIt(
+        "commonmark",
+        {
+            "html": True,
+            "linkify": True,
+            "typographer": True,
+        },
+    )
+    .enable("table")
+    .enable("strikethrough")
+    .enable("tasklist")
+)
 MARKDOWN_ROOT = os.path.abspath(".")
 EXCLUDED_DIRS = {'.git', '.venv', '__pycache__', 'node_modules', '.ruff_cache'}
 


### PR DESCRIPTION
## Summary
- improve GitHub-style Markdown support by enabling tables, strikethrough and tasklists
------
https://chatgpt.com/codex/tasks/task_e_684462f2e2e4832aae2965d1f9902806