### PR TITLE
Fix markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Open [http://127.0.0.1:5000](http://127.0.0.1:5000/) in your browser.
 
 ## 🚀 Features
 
-- ✅ GitHub-style rendering via `markdown-it-py` + GitHub CSS
+- ✅ GitHub-style rendering using `MarkdownIt("gfm-like")` + GitHub CSS
 - ✅ Auto-expandable file tree using `<details>`
 - ✅ Live filtering with reset button
 - ✅ Backend-powered search:

--- a/src/mdviewer/app.py
+++ b/src/mdviewer/app.py
@@ -15,7 +15,16 @@ app = Flask(
     template_folder=os.path.join(BASE_DIR, "templates"),
     static_folder=os.path.join(BASE_DIR, "static"),
 )
-md = MarkdownIt()
+
+# Use GitHub-style Markdown rendering via the built-in gfm-like preset
+md = MarkdownIt(
+    "gfm-like",
+    {
+        "html": True,
+        "linkify": True,
+        "typographer": True,
+    },
+)
 MARKDOWN_ROOT = os.path.abspath(".")
 EXCLUDED_DIRS = {'.git', '.venv', '__pycache__', 'node_modules', '.ruff_cache'}
 


### PR DESCRIPTION
## Summary
- improve GitHub-style Markdown support by using the built-in `gfm-like` preset
- document the preset in the README

------
https://chatgpt.com/codex/tasks/task_e_684462f2e2e4832aae2965d1f9902806