### PR TITLE
Add footnote reference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ mdv
 ## 🚀 Features
 
 - ✅ GitHub-style rendering via `markdown-it-py` + GitHub CSS
+- ✅ Footnote references with links to definitions and return links
 - ✅ Auto-expandable file tree using `<details>`
 - ✅ Live filtering with reset button
 - ✅ Backend-powered search:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "flask",
   "livereload",
   "markdown-it-py",
+  "mdit-py-plugins>=0.4.2",
   "beautifulsoup4"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask
 markdown-it-py
+mdit-py-plugins>=0.4.2
 beautifulsoup4
 livereload
-

--- a/src/mdviewer/app.py
+++ b/src/mdviewer/app.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from flask import Flask, abort, render_template, request, send_from_directory
 from livereload import Server
 from markdown_it import MarkdownIt
+from mdit_py_plugins.footnote import footnote_plugin
 
 from mdviewer.search.fd_search import search_filenames
 from mdviewer.search.rg_search import search_content
@@ -18,7 +19,7 @@ app = Flask(
     template_folder=os.path.join(BASE_DIR, "templates"),
     static_folder=os.path.join(BASE_DIR, "static"),
 )
-md = MarkdownIt().enable("table", "strikethrough")
+md = MarkdownIt().enable("table", "strikethrough").use(footnote_plugin, inline=False)
 MARKDOWN_ROOT = os.path.abspath(".")
 EXCLUDED_DIRS = {'.git', '.venv', '__pycache__', 'node_modules', '.ruff_cache'}
 

--- a/tests/test_footnotes.py
+++ b/tests/test_footnotes.py
@@ -1,0 +1,30 @@
+import unittest
+
+from bs4 import BeautifulSoup
+
+from mdviewer.app import md
+
+
+class FootnoteRenderingTest(unittest.TestCase):
+    def test_reference_links_to_definition_and_back(self):
+        html = md.render(
+            "The mystery becomes clear.[^1]\n\n[^1]: A reference with **Markdown**.\n"
+        )
+        soup = BeautifulSoup(html, "html.parser")
+
+        reference = soup.select_one("sup.footnote-ref > a")
+        self.assertIsNotNone(reference)
+        self.assertEqual(reference["id"], "fnref1")
+        self.assertEqual(reference["href"], "#fn1")
+
+        definition = soup.select_one("li#fn1")
+        self.assertIsNotNone(definition)
+        self.assertIsNotNone(definition.select_one("strong"))
+
+        back_reference = definition.select_one("a.footnote-backref")
+        self.assertIsNotNone(back_reference)
+        self.assertEqual(back_reference["href"], "#fnref1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enable standard Markdown footnote references and definitions
- render links from each reference to its definition and return links back to the text
- add the `mdit-py-plugins` dependency and regression coverage
- document footnote support in the feature list

## Why

The core Markdown parser did not have a footnote extension enabled, so `[^1]` references and their definitions were displayed as literal text. This adds GitHub-style navigation while keeping nonstandard inline footnotes disabled.

Closes #9.

## Validation

- `python -m unittest discover -s tests -v`
- `ruff check src tests`
- `ruff format --check src tests`